### PR TITLE
Add support for user static DNS file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,10 @@ RUN echo "echo -e 'Updating static DNS:\n' && /system/bin/update-static-dns && e
     busybox ln -s /system/bin/update-static-dns /data/data/com.termux/files/usr/bin/update-static-dns && \
     busybox ln -s /system/etc/static-dns-hosts.txt /data/data/com.termux/files/usr/etc/static-dns-hosts.txt
 
+# Create empty user static DNS cache (external bind)
+RUN busybox touch /data/data/com.termux/files/home/.static-dns-hosts.txt && \
+    busybox chown 1000:1000 /data/data/com.termux/files/home/.static-dns-hosts.txt
+
 # Update static DNS cache, install updates and cleanup when not building for arm.
 ENV PATH /data/data/com.termux/files/usr/bin
 RUN if [ ${BOOTSTRAP_ARCH} == 'arm' ]; then exit; else \

--- a/system/arm/bin/update-static-dns
+++ b/system/arm/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/x86/bin/update-static-dns
+++ b/system/x86/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then


### PR DESCRIPTION
Adds the file `/data/data/com.termux/files/home/.static-dns-hosts.txt` with empty content to bind to it externally with some user hosts. The script `update-static-dns` then uses the regular system wide `static-dns-hosts.txt` and the content of this file. The user can edit it inside the container, or bind to it with an external file.